### PR TITLE
[Bug-12] Fix double activity issue on Android 14 notification click

### DIFF
--- a/android-sdk-ui/src/main/AndroidManifest.xml
+++ b/android-sdk-ui/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     <activity
       android:name="com.braze.push.NotificationTrampolineActivity"
       android:exported="false"
+      android:excludeFromRecents="true"
+      android:taskAffinity=".NotificationTrampolineActivity"
       android:launchMode="singleInstance"
       android:theme="@style/Braze.PushTrampoline.Transparent" />
 


### PR DESCRIPTION
Fixes #12 

**Background:**
- Based on the logs attached in the issue, the `NotificationTrampolineActivity` continues to stay in the Recents drawer even though the `finish()` method was called [here](https://github.com/braze-inc/braze-android-sdk/blob/master/android-sdk-ui/src/main/java/com/braze/push/NotificationTrampolineActivity.kt#L57). Once, it launches the requested activity, it should no longer be visible similar to how it behaves on other Android versions. 

**Changes:**

I am not sure if this is the best fix for this issue but based on my investigation, this should fix the bug. Looking forward to feedback from collaborators on how best to address this issue. 

- Adding the `excludeFromRecents` flag seems to fix the problem. In addition to it, i am adding the `taskAffinity` flag just for safety.
  - More details on this flag can be found in [Android docs](https://developer.android.com/guide/topics/manifest/activity-element) and also in this [SO post](https://stackoverflow.com/questions/23713124/why-does-excludefromrecents-remove-all-activities)
  - The OneSignal Push Notification Android SDK [uses the same flags for its notification opener activity](https://github.com/OneSignal/OneSignal-Android-SDK/blob/main/OneSignalSDK/onesignal/src/main/AndroidManifest.xml#L133)

## Testing

Tested on multiple Android versions. 

| Android version | Video After fix |
|----| ---- |
| Android 14 | https://github.com/braze-inc/braze-android-sdk/assets/117751562/923fcea8-21a3-47af-8f0a-737e48bacfd7 |
| Android 13 | https://github.com/braze-inc/braze-android-sdk/assets/117751562/90bc66ae-98d3-4214-9a9a-7cc1532bff63| 
| Android 12 | https://github.com/braze-inc/braze-android-sdk/assets/117751562/a3390926-330d-448d-91e9-02fd9333c1ac |



