### PR TITLE
Fixed `Activity` getting leak

### DIFF
--- a/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/InAppMessageManagerBase.kt
+++ b/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/InAppMessageManagerBase.kt
@@ -20,6 +20,7 @@ import com.braze.ui.inappmessage.listeners.DefaultInAppMessageWebViewClientListe
 import com.braze.ui.inappmessage.listeners.IHtmlInAppMessageActionListener
 import com.braze.ui.inappmessage.listeners.IInAppMessageManagerListener
 import com.braze.ui.inappmessage.listeners.IInAppMessageWebViewClientListener
+import java.lang.ref.WeakReference
 
 @Suppress("TooManyFunctions")
 open class InAppMessageManagerBase {
@@ -54,7 +55,7 @@ open class InAppMessageManagerBase {
      */
     @JvmField
     @Suppress("VariableNaming")
-    protected var mActivity: Activity? = null
+    protected var mActivity: WeakReference<Activity>? = null
 
     @JvmField
     @Suppress("VariableNaming")
@@ -63,7 +64,7 @@ open class InAppMessageManagerBase {
     // These serve the purpose of allowing people to write more Kotlin-friendly code, but also provide
     // the getActivity() and getApplicationContext() Java generated code for backwards compatibility
     open val activity
-        get() = mActivity
+        get() = mActivity?.get()
 
     open val applicationContext
         get() = mApplicationContext


### PR DESCRIPTION
Fixes memory leak in `BrazeInAppMessageManager` logic by using a `WeakReference`.

> We cannot share the View because doing so would create a memory leak.

This statement is not correct, since either keeping a strong reference to the `View` or its `Activity` will leak the whole Android `Context`, as it's reported by this `LeakCanary` report:
```
151613 bytes retained by leaking objects
Signature: e86d1f90ed6b9dd948d488675e2af0fb223d02c7
┬───
│ GC Root: Thread object
│
├─ android.app.Instrumentation$InstrumentationThread instance
│    Leaking: NO (PathClassLoader↓ is not leaking)
│    Thread name: 'Instr: com.glovoapp.test.GlovoAndroidJUnitRunner'
│    ↓ Thread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (BrazeInAppMessageManager↓ is not leaking and A ClassLoader is never leaking)
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (BrazeInAppMessageManager↓ is not leaking)
│    ↓ Object[15009]
├─ com.braze.ui.inappmessage.BrazeInAppMessageManager class
│    Leaking: NO (a class is never leaking)
│    ↓ static BrazeInAppMessageManager.instance
│                                      ~~~~~~~~
├─ com.braze.ui.inappmessage.BrazeInAppMessageManager instance
│    Leaking: UNKNOWN
│    Retaining 152.1 kB in 3265 objects
│    mActivity instance of com.glovoapp.account.faq.FAQActivity with mDestroyed = true
│    mApplicationContext instance of com.glovoapp.HiltUiTestApp_Application
│    ↓ InAppMessageManagerBase.mActivity
│                              ~~~~~~~~~
╰→ com.glovoapp.account.faq.FAQActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.glovoapp.account.faq.FAQActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
​     Retaining 151.6 kB in 3244 objects
​     key = 8e9c5039-abaa-4bd9-b6d8-8872eba5c4ea
​     watchDurationMillis = 115770
​     retainedDurationMillis = 110762
​     mApplication instance of com.glovoapp.HiltUiTestApp_Application
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper
```