### PR TITLE
Fix: Remove hardcoded Toast for network error in ContentCardsFragment

### DIFF
--- a/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt
+++ b/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt
@@ -6,7 +6,6 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -343,13 +342,6 @@ open class ContentCardsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListen
      */
     protected suspend fun networkUnavailable() {
         brazelog(V) { "Displaying network unavailable toast." }
-        context?.applicationContext?.let { applicationContext ->
-            Toast.makeText(
-                applicationContext,
-                applicationContext.getString(R.string.com_braze_feed_connection_error_title),
-                Toast.LENGTH_LONG
-            ).show()
-        }
         swapRecyclerViewAdapter(emptyCardsAdapter)
         contentCardsSwipeLayout?.isRefreshing = false
     }


### PR DESCRIPTION
## Summary
Removes the hardcoded `Toast` message that is displayed when network is unavailable while loading Content Cards in [ContentCardsFragment](cci:2://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:39:0-368:1).

## Problem
The [[ContentCardsFragment](cci:2://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:39:0-368:1)](https://github.com/braze-inc/braze-android-sdk/blob/master/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt#L344-L355) was showing a `Toast.makeText()` message with `R.string.com_braze_feed_connection_error_title` whenever network was unavailable. This hardcoded behavior impacts all SDK consumers and may not align with their app's UX/UI guidelines or error handling strategy.

## Solution
Removed the `Toast.makeText()` call from the [[networkUnavailable()](cci:1://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:339:4-346:5)](https://github.com/braze-inc/braze-android-sdk/blob/master/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt#L344) function. The function now only:
- Logs the network unavailability event
- Shows the empty cards adapter  
- Stops the refresh indicator

This aligns the behavior with the Jetpack Compose [[ContentCardsList](cci:1://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-jetpack-compose/src/main/java/com/braze/jetpackcompose/contentcards/ContentCardsList.kt:61:0-444:1)](https://github.com/braze-inc/braze-android-sdk/blob/master/android-sdk-jetpack-compose/src/main/java/com/braze/jetpackcompose/contentcards/ContentCardsList.kt#L132-L136) implementation, which also only logs network unavailability without displaying a Toast.

## Changes
**Modified:**
- [[android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt](cci:7://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:0:0-0:0)](https://github.com/braze-inc/braze-android-sdk/blob/master/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt)
  - Removed `Toast.makeText()` call from [networkUnavailable()](cci:1://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:339:4-346:5)
  - Removed unused `android.widget.Toast` import

## Customization
SDK consumers who need to display custom network error UI can subclass [ContentCardsFragment](cci:2://file:///Users/jaypatelbond/StudioProjects/braze-android-sdk/android-sdk-ui/src/main/java/com/braze/ui/contentcards/ContentCardsFragment.kt:39:0-368:1) and override the `protected suspend fun networkUnavailable()` function.

## Testing
- [x] Verified Content Cards displays empty adapter when network is unavailable
- [x] Verified no Toast is shown to the user
- [x] Verified refresh indicator stops spinning appropriately
- [x] Verified existing functionality remains intact