### PR TITLE
Clear in-app message queue on user change to prevent stale message presentation

### DIFF
--- a/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/BrazeInAppMessageManager.kt
+++ b/android-sdk-ui/src/main/java/com/braze/ui/inappmessage/BrazeInAppMessageManager.kt
@@ -706,11 +706,16 @@ open class BrazeInAppMessageManager : InAppMessageManagerBase() {
             brazelog(V) { "InAppMessage manager handling new current user id: '$event'" }
             val currentUserId = event.currentUserId
             this.currentUserId = currentUserId
-            brazelog { "Removing in-app messages not from user $currentUserId" }
+            brazelog { "Clearing all queued in-app messages for user change to $currentUserId" }
 
-            inAppMessageStack.removeAll { !isInAppMessageForTheSameUser(it, currentUserId) }
-            if (!isInAppMessageForTheSameUser(carryoverInAppMessage, currentUserId)) carryoverInAppMessage = null
-            if (!isInAppMessageForTheSameUser(unregisteredInAppMessage, currentUserId)) unregisteredInAppMessage = null
+            // Clear all queued messages unconditionally on user change to prevent
+            // stale messages (e.g. re-enqueued via DISPLAY_LATER) from being
+            // presented to the wrong user. Messages without a tracked userId in
+            // inAppMessageEventMap would otherwise pass the per-user filter.
+            inAppMessageStack.clear()
+            inAppMessageEventMap.clear()
+            carryoverInAppMessage = null
+            unregisteredInAppMessage = null
             if (displayingInAppMessage.get()) {
                 hideCurrentlyDisplayingInAppMessage(false)
             }


### PR DESCRIPTION
## Summary

- **Bug:** Re-enqueued in-app messages from a previous user session can be presented after `changeUser()` is called. On iOS this causes an EXC_BREAKPOINT crash in the WebView bridge; on Android the same stale message presentation issue exists.
- **Root cause:** `BrazeInAppMessageManager.createBrazeUserChangeEventSubscriber` filtered queued messages using `isInAppMessageForTheSameUser()`, which returns `true` when a message has no entry in `inAppMessageEventMap` or when the event's `userId` is null. Messages re-enqueued via `DISPLAY_LATER` (pushed back onto `inAppMessageStack`) could therefore survive a user change.
- **Fix:** On user change, unconditionally clear `inAppMessageStack`, `inAppMessageEventMap`, `carryoverInAppMessage`, and `unregisteredInAppMessage` — matching the existing `SdkDataWipeEvent` handler behavior. Any currently-displaying message is also hidden.

This is a minimal, focused change (4 lines replaced in one method).

Refs: https://github.com/braze-inc/braze-swift-sdk/issues/191

## Test plan

- [ ] Call `changeUser()` while in-app messages are queued (via `DISPLAY_LATER`) — verify they are not presented to the new user
- [ ] Call `changeUser()` while an in-app message is currently displayed — verify it is dismissed
- [ ] Verify new in-app messages for the new user are still received and displayed correctly after `changeUser()`
- [ ] Verify `SdkDataWipeEvent` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)